### PR TITLE
Loosen react peer version constraints to allow for 16.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.8",
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "trim-canvas": "^0.1.0"


### PR DESCRIPTION
This fork is a fork of a fork and not easily updateable from the (now) overhauled upstream repo @ https://github.com/blackjk3/react-signature-pad